### PR TITLE
set `PrivateAssets="All"` for all dependencies

### DIFF
--- a/LC-API/LC-API.csproj
+++ b/LC-API/LC-API.csproj
@@ -44,13 +44,13 @@
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="BepInEx.Core" Version="5.*" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
+    <PackageReference Include="BepInEx.Core" Version="5.*" PrivateAssets="all" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" PrivateAssets="all" />
     <PackageReference Include="MinVer" Version="4.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile" />
+    <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile" PrivateAssets="all" />
     <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" />
   </ItemGroup>
   
@@ -83,7 +83,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="$(CI) == 'true'">
-    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="45.0.2-alpha.1" />
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="45.0.2-alpha.1" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup Condition="$(CI) == 'true'">


### PR DESCRIPTION
Prevents `PackageReference`s being added as transitive dependencies on NuGet package