### PR TITLE
Updated file structure for manual installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ BepinEx
 ├───core
 ├───patchers
 └───plugins
-        └───2018-LC_API
-        │   LC_API.dll
-        │
-        └───Bundles
-                networking
+    └───2018-LC_API
+        ├───Bundles
+        │   └───networking
+        └───LC_API.dll
 ```
 
 # TODO


### PR DESCRIPTION
I noticed the README did not list the `Bundles` folder as a subdirectory of `2018-LC_API`. I ran `tree` on my BepInEx folder and got this result.